### PR TITLE
[Fix]nginxでgunicorn側にリクエストを送るように設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   nginx:
     build: ./nginx
     ports:
-      - 5000:80
+      - 8080:80
     depends_on:
       - web
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 version: '3'
-
 services:
-
   web:
     build: ./web
+    container_name: web
+    expose:
+      - 5000
     networks:
       - nginx_network
-    ports:
-      - 8000:5000
 
   nginx:
     build: ./nginx

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,5 @@
 upstream hello_app {
-    server web:8000;
+    server web:5000;
 }
 
 server {


### PR DESCRIPTION
http://hello_world.excite.co.jp:8000/hello

で動作確認して安心していたが実際は
http://hello_world.excite.co.jp:5000/hello
で動かなければならない。

しかし、実際に動作すると動いていなかったため修正を行った。

# 変更点

- gunicorn側のcompose.ymlは外に公開する必要がないためexposeで5000(gunicornのbindポート)を設定するように修正

- nginx側はありきたりな8080に修正